### PR TITLE
docs(loader): sync Hook_Loader page from Loader 1.3.0 README

### DIFF
--- a/lib/Hook_Loader.md
+++ b/lib/Hook_Loader.md
@@ -1,226 +1,318 @@
 # Hook_Loader
 
-The PinkCrab Hook Hook_Loader.
+An object-based WordPress hook loader. Register actions, filters, AJAX endpoints and shortcodes against `Hook_Loader`, then call `register_hooks()` to commit them to WordPress. Supports admin-only, front-only, and removal of hooks (including hooks registered against class instances you no longer hold).
 
+[![Latest Stable Version](https://poser.pugx.org/pinkcrab/hook-loader/v)](https://packagist.org/packages/pinkcrab/hook-loader)
+[![Total Downloads](https://poser.pugx.org/pinkcrab/hook-loader/downloads)](https://packagist.org/packages/pinkcrab/hook-loader)
+[![License](https://poser.pugx.org/pinkcrab/hook-loader/license)](https://packagist.org/packages/pinkcrab/hook-loader)
+[![PHP Version Require](https://poser.pugx.org/pinkcrab/hook-loader/require/php)](https://packagist.org/packages/pinkcrab/hook-loader)
+![GitHub contributors](https://img.shields.io/github/contributors/Pink-Crab/Loader?label=Contributors)
+![GitHub issues](https://img.shields.io/github/issues-raw/Pink-Crab/Loader)
 
-![alt text](https://img.shields.io/badge/Current_Version-1.1.2-yellow.svg?style=flat " ") 
-[![Open Source Love](https://badges.frapsoft.com/os/mit/mit.svg?v=102)](https://github.com/ellerbrock/open-source-badge/)
-![](https://github.com/Pink-Crab/Loader/workflows/GitHub_CI/badge.svg " ")
+[![WP 6.6 [PHP8.0-8.4] Tests](https://github.com/Pink-Crab/Loader/actions/workflows/WP_6_6.yaml/badge.svg)](https://github.com/Pink-Crab/Loader/actions/workflows/WP_6_6.yaml)
+[![WP 6.7 [PHP8.0-8.4] Tests](https://github.com/Pink-Crab/Loader/actions/workflows/WP_6_7.yaml/badge.svg)](https://github.com/Pink-Crab/Loader/actions/workflows/WP_6_7.yaml)
+[![WP 6.8 [PHP8.0-8.4] Tests](https://github.com/Pink-Crab/Loader/actions/workflows/WP_6_8.yaml/badge.svg)](https://github.com/Pink-Crab/Loader/actions/workflows/WP_6_8.yaml)
+[![WP 6.9 [PHP8.0-8.4] Tests](https://github.com/Pink-Crab/Loader/actions/workflows/WP_6_9.yaml/badge.svg)](https://github.com/Pink-Crab/Loader/actions/workflows/WP_6_9.yaml)
+
 [![codecov](https://codecov.io/gh/Pink-Crab/Loader/branch/master/graph/badge.svg?token=94DFTAVAAI)](https://codecov.io/gh/Pink-Crab/Loader)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Pink-Crab/Loader/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Pink-Crab/Loader/?branch=master)
 
-For more details please visit our docs.
-https://app.gitbook.com/@glynn-quelch/s/pinkcrab/
+For more details please visit the docs site: https://perique.info/lib/Hook_Loader.html
 
-## Version ##
+## Why?
 
-**Release 1.1.2**
+WordPress — and especially WooCommerce — is built around hooks. Wiring up actions and filters with `add_action()` / `add_filter()` scattered across classes gets hard to reason about quickly: there's no single place to see what's registered, admin-only vs front-only conditions end up duplicated, and removing hooks added by class instances is a known pain.
 
-> Since v1.0.0 we have made some changes to have this all works under the hood, we have changed from Loader to Hook_Loader as the main class, but Loader has been left in as pollyfill for older versions.
+`Hook_Loader` gives you a single object to declare everything against. You stage your hooks, then flush them to WordPress in one call (`register_hooks()`), which means your class constructors stay side-effect-free and your test harness can inspect the staged hooks before they reach `$wp_filter`.
 
-## Why? ##
-
-WordPress and especially WooCommerce is built around hooks and if you have to register a lot of them, it can be hard to keep track of them all and what is currently being registered with WP. 
-
-The PinkCrab Hook_Loader gives a more manageable way of registering and removing hook call, shortcode and ajax calls.
-
-
-## Setup ##
-
-```bash 
-$ composer require pinkcrab/hook-loader
-
-``` 
-
-Once you have the hook loader installed it just case of putting it to use. As this is all held as a class, you can pass the instance as depenedecnies to any class you wish to give access to the loader.
-
-## Registering Hooks (actions & filters)
-> **Hook_Loader::action(string $hook, callable $method, int $priority=10, int $args = 1): void**
-
-> **Hook_Loader::admin_action(string $hook, callable $method, int $priority=10, int $args = 1): void**
-
-> **Hook_Loader::front_action(string $hook, callable $method, int $priority=10, int $args = 1): void**
-
-> **Hook_Loader::filter(string $hook, callable $method, int $priority=10, int $args = 1): void**
-
-> **Hook_Loader::admin_filter(string $hook, callable $method, int $priority=10, int $args = 1): void**
-
-> **Hook_Loader::front_filter(string $hook, callable $method, int $priority=10, int $args = 1): void**
-
-```php
-$loader = new Hook_Loader();
-
-// Add actions
-$loader->action('some_action', 'my_callback'); // Registered front and admin
-$loader->front_action('some_action', 'my_callback'); // Frontend only
-$loader->admin_action('some_action', 'my_callback'); // Admin only
-
-// Filters
-$loader->filter('some_filter', 'strtolower'); // Registered front and admin
-$loader->front_filter('some_filter', 'strtolower'); // Frontend only
-$loader->admin_filter('some_filter', 'strtolower'); // Admin only
-
-// Remove hooks
-$loader->remove('some_action', 'someone_else_callback', 10); 
-$loader->remove_filter('some_action', 'someone_else_callback', 10); // Does the same as remove()
-$loader->remove_action('some_action', 'someone_else_callback', 10); // Does the same as remove()
-
-// Ajax and Shortcode.
-$loader->shortcode('my_shortcode', 'shortcode_callback');
-$loader->ajax('my_action', 'my_callback', true, true);
-
-// Once all have been added, just process with 
-$loader->register_hooks();
-
-```
-
-### Use with a class.
-
-``` php
-class SomeAction{
-	/**	
-	 * Register all hooks for this class
-	 * @param Hook_Loader $loader
-	 * @return void
-	 */
-	public function hooks(Hook_Loader $loader){
-		$loader->action('action_handle', [$this, 'some_method')], 20);
-	}
-
-	// The callback
-	public function some_method(){
-		print 'I WAS CALLED';
-	}
-}
-
-// In your code, just pass the loader to this class.
-$loader = new Hook_Loader();
-$some_action = new SomeAction();
-
-// Add all the some_action hooks to loader and register them.
-$some_action->hooks($loader);
-$loader->register_hooks();
-
-```
-
-## Hook Removal (actions & filters)
-> **Hook_Loader::remove(string $hook, callable $method, int $priority=10): void**
-
-> **Hook_Loader::remove_filter(string $hook, callable $method, int $priority=10): void**
-
-> **Hook_Loader::remove_hook(string $hook, callable $method, int $priority=10): void**
-
-While remove_action() and remove_filter() are prefectly suitable 90% of the time, it can be tricky to unset hooks with have been added as isntance to classes, you can not recall the same instance. Out Hook_Removal class will manually remove all hooks based on the class name (instance or static use). Allowing for the removal of hooks created by other plugins. 
-
-Even if the hook was added via a class instance, you only need to use the class name to add the method used. This allows the avoidance of having to recreate an instance of the class and potentially rerunning other hooks and setup routines.
-
-``` php
-// The above hook can be removed using
-
-// Just the full class name (doesnt run autload)
-$loader->remove('action_handle', [SomeAction::class, 'some_method'], 20);
-
-// Or as a new instance
-$loader->remove('action_handle', [new SomeAction(), 'some_method'], 20);
-```
-
-## Shortcodes
-> **Hook_Loader::shortcode(string $hook, callable $method): void**
-
-You can easily add shortcodes using the loader, not only that you ensure they come with fully populated objects behind them
-
-``` php
-// Simple example
-$loader->shortcode(
-	'testShortCode',
-	function( $atts ) {
-		echo $atts['text'];
-	}
-);
-
-// Called with shortcode as normal (either in php or wp-admin text input) 
-do_shortcode( "[testShortCode text='yes']" ); // yes
-
-// Part of a class
-class ShortCode {
-
-	protected $some_service;
-
-	public function __construct(Some_Service $some_service){
-		$this->some_service = $some_service;
-	}
-
-	public function register(Hook_Loader $loader){
-		$loader->shortcode('my_shortcode', [$this, ['render_shortcode']]);
-	}
-
-	public function render_shortcode(array $args){
-		print $this->some_service->do_something($args['something']);
-	}
-}
-
-```
-## Ajax
-> **Hook_Loader::ajax(string $hook, callable $method, bool $public, bool $private): void**
-
-If you want to register ajax calls, it requires 2 hook calls. This soon gets messy if you are setting up multiple calls. The Hook_Loader can handle registering either or both of this with a single declaration.
-
-```php
-
-$loader->ajax('my_action', 'my_callback', true, true); // For both logged in and out users.
-$loader->ajax('my_action', 'my_callback', false, true); // For only logged in users.
-$loader->ajax('my_action', 'my_callback', true, false); // For only logged out users.
-```
-As with the other examples this can be used as part of class to create self contained ajax calls. While this can be done manually, the Registerables package comes with a very useful Ajax abstract class which can be used.
-
-
-## Testing ##
-
-To run the full suite (as run via GH CLI)
+## Install
 
 ```bash
-	composer all
+composer require pinkcrab/hook-loader
 ```
 
-### PHP Unit ###
+Then include the Composer autoloader in your project:
 
-If you would like to run the tests for this package, please ensure you add your database details into the test/wp-config.php file before running phpunit.
-
-```bash 
-$ composer test
-
-``` 
-
-Run with coverage report (/coverage-report)
-```bash 
-$ composer coverage
+```php
+require_once __DIR__ . '/vendor/autoload.php';
 ```
 
-### PHP Stan ###
+All registration methods return the created `Hook` object. Nothing binds to WordPress until you call `$loader->register_hooks()` — until then hooks are just staged in the collection.
 
-The module comes with a pollyfill for all WP Functions, allowing for the testing of all core files. The current config omits the Dice file as this is not ours. To run the suite call.
+## Methods (Registration)
 
-```bash 
-$ vendor/bin/phpstan analyse src/ -l8 
+### action
+**action( string $handle, callable $callback, int $args = 1, int $priority = 10 ): Hook**
+> @param string $handle Hook handle to register against.  
+> @param callable $callback Hook callback.  
+> @param int $args Number of arguments passed to the callback. Default 1.  
+> @param int $priority Priority the hook fires at. Default 10.  
+> @return \PinkCrab\Loader\Hook  
 
-``` 
-```bash 
-$ composer analyse
+Registers an action on both admin and front-end contexts. Equivalent to `add_action($handle, $callback, $priority, $args)` when flushed.
+
+*Example*
+```php
+$loader->action( 'init', 'my_init_callback' );
+$loader->action( 'save_post', [ $saver, 'handle' ], 2, 20 );
 ```
 
-### PHPCS ###
+### admin_action
+**admin_action( string $handle, callable $callback, int $args = 1, int $priority = 10 ): Hook**
+> @param string $handle Hook handle to register against.  
+> @param callable $callback Hook callback.  
+> @param int $args Number of arguments passed to the callback. Default 1.  
+> @param int $priority Priority the hook fires at. Default 10.  
+> @return \PinkCrab\Loader\Hook  
 
-You can run the codebase thorough PHPCS by calling.
-```bash 
-$ composer sniff
+Same as `action()` but only registers when the request is inside `wp-admin` (checked at flush time via `is_admin()`).
+
+*Example*
+```php
+$loader->admin_action( 'admin_menu', [ $menu, 'register' ] );
 ```
 
-## License ##
+### front_action
+**front_action( string $handle, callable $callback, int $args = 1, int $priority = 10 ): Hook**
+> @param string $handle Hook handle to register against.  
+> @param callable $callback Hook callback.  
+> @param int $args Number of arguments passed to the callback. Default 1.  
+> @param int $priority Priority the hook fires at. Default 10.  
+> @return \PinkCrab\Loader\Hook  
 
-### MIT License ###
+Same as `action()` but only registers on the front-end (when `is_admin()` is false).
 
-http://www.opensource.org/licenses/mit-license.html  
+*Example*
+```php
+$loader->front_action( 'wp_enqueue_scripts', [ $assets, 'enqueue' ] );
+```
 
-## Change Log ##
+### filter
+**filter( string $handle, callable $callback, int $args = 1, int $priority = 10 ): Hook**
+> @param string $handle Hook handle to register against.  
+> @param callable $callback Filter callback; must return the first argument.  
+> @param int $args Number of arguments passed to the callback. Default 1.  
+> @param int $priority Priority the hook fires at. Default 10.  
+> @return \PinkCrab\Loader\Hook  
+
+Registers a filter on both admin and front-end contexts.
+
+*Example*
+```php
+$loader->filter( 'the_content', 'my_content_filter' );
+$loader->filter( 'wp_nav_menu_items', [ $menu, 'append' ], 2, 50 );
+```
+
+### admin_filter
+**admin_filter( string $handle, callable $callback, int $args = 1, int $priority = 10 ): Hook**
+> @param string $handle Hook handle to register against.  
+> @param callable $callback Filter callback; must return the first argument.  
+> @param int $args Number of arguments passed to the callback. Default 1.  
+> @param int $priority Priority the hook fires at. Default 10.  
+> @return \PinkCrab\Loader\Hook  
+
+Same as `filter()` but only registers inside `wp-admin`.
+
+*Example*
+```php
+$loader->admin_filter( 'post_row_actions', [ $rows, 'add_action' ], 2 );
+```
+
+### front_filter
+**front_filter( string $handle, callable $callback, int $args = 1, int $priority = 10 ): Hook**
+> @param string $handle Hook handle to register against.  
+> @param callable $callback Filter callback; must return the first argument.  
+> @param int $args Number of arguments passed to the callback. Default 1.  
+> @param int $priority Priority the hook fires at. Default 10.  
+> @return \PinkCrab\Loader\Hook  
+
+Same as `filter()` but only registers on the front-end.
+
+*Example*
+```php
+$loader->front_filter( 'body_class', [ $body, 'classes' ], 1, 20 );
+```
+
+## Methods (Removal)
+
+### remove
+**remove( string $handle, $callback, int $priority = 10 ): Hook**
+> @param string $handle Hook handle to remove from.  
+> @param callable|array{0:string,1:string} $callback Callable, or `[class-name, method-name]` array (both strings).  
+> @param int $priority Priority the target hook was registered at. Default 10.  
+> @return \PinkCrab\Loader\Hook  
+
+WordPress's native `remove_action()` / `remove_filter()` require the *same* callable you passed to `add_action()`. That breaks for hooks added against class instances — you need the original `$instance` and that's often gone or inaccessible. `Hook_Removal` walks `$wp_filter` and matches on class name + method name instead, so a `[class-name, method-name]` array is enough.
+
+*Example*
+```php
+// Match by class name only — no need to reconstruct an instance.
+$loader->remove( 'init', [ Some_Other_Plugin_Action::class, 'boot' ], 10 );
+
+// Works equivalently with an instance, if you have one.
+$loader->remove( 'init', [ $instance, 'boot' ], 10 );
+
+// Plain callables also work.
+$loader->remove( 'init', 'some_global_function', 10 );
+```
+
+### remove_action
+**remove_action( string $handle, $callback, int $priority = 10 ): Hook**
+> @param string $handle Hook handle to remove from.  
+> @param callable|array{0:string,1:string} $callback Callable, or `[class-name, method-name]` array.  
+> @param int $priority Priority the target hook was registered at. Default 10.  
+> @return \PinkCrab\Loader\Hook  
+
+Alias for `remove()` that signals intent at the call-site when you're removing an action. Identical runtime behaviour — WordPress stores actions and filters in the same `$wp_filter` registry.
+
+*Example*
+```php
+// Global function added via add_action() elsewhere.
+$loader->remove_action( 'save_post', 'someone_elses_saver', 10 );
+
+// Instance-method action registered by a third-party plugin — match by class name.
+$loader->remove_action(
+    'init',
+    [ \Other_Plugin\Bootstrap::class, 'register' ],
+    10
+);
+
+// Or pass a live instance if you happen to hold one.
+$loader->remove_action( 'init', [ $existing_instance, 'register' ], 10 );
+```
+
+### remove_filter
+**remove_filter( string $handle, $callback, int $priority = 10 ): Hook**
+> @param string $handle Hook handle to remove from.  
+> @param callable|array{0:string,1:string} $callback Callable, or `[class-name, method-name]` array.  
+> @param int $priority Priority the target hook was registered at. Default 10.  
+> @return \PinkCrab\Loader\Hook  
+
+Alias for `remove()` that signals intent at the call-site when you're removing a filter. Identical runtime behaviour to `remove()` / `remove_action()`.
+
+*Example*
+```php
+// Unregister a filter that another plugin added by class.
+$loader->remove_filter(
+    'the_content',
+    [ \Third_Party\Content_Filter::class, 'wrap' ],
+    10
+);
+
+// Unregister a WP core filter callback by name.
+$loader->remove_filter( 'the_content', 'wpautop', 10 );
+
+// Swap a third-party filter for your own at the same priority:
+$loader->remove_filter( 'the_title', [ \Other_Plugin\Titles::class, 'prefix' ], 20 );
+$loader->filter(        'the_title', [ $this, 'prefix' ], 1, 20 );
+$loader->register_hooks();
+```
+
+## Methods (Shortcodes & Ajax)
+
+### shortcode
+**shortcode( string $handle, callable $callback ): Hook**
+> @param string $handle Shortcode tag.  
+> @param callable $callback Shortcode callback. Receives the attributes array and must return a string.  
+> @return \PinkCrab\Loader\Hook  
+
+Registers a shortcode. Runs `add_shortcode()` when `register_hooks()` fires.
+
+*Example*
+```php
+$loader->shortcode( 'my_shortcode', function ( array $atts ): string {
+    return esc_html( $atts['text'] ?? '' );
+} );
+
+// Somewhere later:
+do_shortcode( "[my_shortcode text='hello']" );
+```
+
+### ajax
+**ajax( string $handle, callable $callback, bool $public_ajax = true, bool $private_ajax = true ): Hook**
+> @param string $handle Ajax action handle (without the `wp_ajax_` / `wp_ajax_nopriv_` prefix).  
+> @param callable $callback Ajax handler callback.  
+> @param bool $public_ajax Register against `wp_ajax_nopriv_<handle>` for anonymous users. Default true.  
+> @param bool $private_ajax Register against `wp_ajax_<handle>` for authenticated users. Default true.  
+> @return \PinkCrab\Loader\Hook  
+
+WordPress splits AJAX into two actions: `wp_ajax_<handle>` (authenticated users) and `wp_ajax_nopriv_<handle>` (anonymous users). `Hook_Loader::ajax()` registers either or both from a single call.
+
+*Example*
+```php
+$loader->ajax( 'my_action', 'my_callback', true,  true  );  // logged in AND logged out
+$loader->ajax( 'my_action', 'my_callback', true,  false );  // logged out only  ($private_ajax=false)
+$loader->ajax( 'my_action', 'my_callback', false, true  );  // logged in only   ($public_ajax=false)
+```
+
+## Methods (Lifecycle)
+
+### register_hooks
+**register_hooks(): void**
+> @return void  
+
+Flushes every staged hook to WordPress. Call once, after all registrations have been declared. Before this is called nothing is bound to `$wp_filter` / `$wp_actions`.
+
+*Example*
+```php
+$loader = new Hook_Loader();
+// ...register hooks...
+$loader->register_hooks();
+```
+
+## Use with a class
+
+Because hooks are staged (not fired immediately), your class constructors stay clean. Expose a `hooks()` method that accepts the loader and records what the class wants registered; the composition root (your plugin bootstrap) flushes them:
+
+```php
+class Some_Action {
+    public function hooks( Hook_Loader $loader ): void {
+        $loader->action( 'init', [ $this, 'boot' ] );
+        $loader->front_filter( 'the_content', [ $this, 'wrap_content' ], 1, 20 );
+    }
+
+    public function boot(): void {
+        // side-effecty init
+    }
+
+    public function wrap_content( string $content ): string {
+        return '<div class="mine">' . $content . '</div>';
+    }
+}
+
+$loader      = new Hook_Loader();
+$some_action = new Some_Action();
+$some_action->hooks( $loader );
+$loader->register_hooks();
+```
+
+## Filtering hooks before registration
+
+The hook collection is passed through a filter before it hits WordPress, letting other code mutate, add, or strip hooks at flush time. Use the `Hook_Collection::REGISTER_HOOKS` constant (or its literal string value `pinkcrab/loader/register_hooks`):
+
+```php
+add_filter( Hook_Collection::REGISTER_HOOKS, function ( $hooks ) {
+    // Inspect, mutate, or replace the staged hooks.
+    return $hooks;
+} );
+```
+
+## Tested Against
+
+* PHP 8.0, 8.1, 8.2, 8.3 & 8.4
+* WP 6.6, 6.7, 6.8 & 6.9
+* MySQL 8.4
+
+## License
+
+### MIT License
+
+http://www.opensource.org/licenses/mit-license.html
+
+## Change Log
+
+* 1.3.0 - Drop PHP 7.x, require PHP 8.0+. Modernise the tooling chain (PHPStan 2.x at level 9, PHPUnit 8|9, WPCS 3.x). Replace the single GitHub_CI workflow with the WP 6.6–6.9 matrix (PHP 8.0–8.4, `mysql:8.4`) using `codecov/codecov-action@v4`. Suppress the WP 6.8 `wp_is_block_theme` early-call notice in `tests/wp-config.php`. Remove `object-calisthenics/phpcs-calisthenics-rules` from dev-deps. **BC break:** `Hook_Loader::ajax()` and `Hook_Factory::ajax()` parameters `$public` / `$private` renamed to `$public_ajax` / `$private_ajax` (positional callers unaffected; named-argument callers need to update). Reserved-keyword parameter names removed throughout (`$callable` / `$function` → `$callback`).
+* 1.2.0 - Updated testing dependencies and support for php8, added in the ability to filter hooks prior to registration.
 * 1.1.2 - Loader::class has now been marked as deprecated
 * 1.1.1 - Typo on register_hooks() (spelt at regster_hooks)
 * 1.1.0 - All internal functionality moved over, still has the same ex


### PR DESCRIPTION
This pull request makes a comprehensive update to the `lib/Hook_Loader.md` documentation, modernizing and expanding it significantly. The new version provides detailed explanations, usage examples, and clear documentation for all public methods, as well as updated badges and compatibility/test information. It also introduces a new changelog entry for version 1.3.0 and clarifies breaking changes.

Key documentation improvements:

**Expanded and Modernized Documentation**
* Provides a thorough introduction, rationale, and installation instructions for `Hook_Loader`, replacing the previous brief overview.
* Documents all public methods (`action`, `filter`, `admin_action`, `front_action`, `remove`, `shortcode`, `ajax`, `register_hooks`, etc.) with clear parameter lists, return values, and usage examples.
* Explains advanced usage such as filtering hooks before registration and using the loader within classes, making it much easier for new users to onboard.

**Project Metadata and Badges**
* Updates and adds project badges for version, downloads, license, PHP requirements, contributors, issues, test matrix, code coverage, and quality, reflecting current project status and CI pipelines.
* Updates documentation links to point to the new docs site. ([lib/Hook_Loader.mdL3-R315](diffhunk://#diff-731c090368be5e21d88f7d84eafbe996da7ca5b3574524962b57636d5342e5d5L3-R315)